### PR TITLE
Fix reactor

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - echo "No tests to run in POM projects"

--- a/pom.xml
+++ b/pom.xml
@@ -6,15 +6,21 @@
 
 	<groupId>com.github.bordertech.common</groupId>
 	<artifactId>java-common</artifactId>
-	<version>1.0.0-SNAPSHOT</version><!-- Never really needs to change, aggregate POM is not released -->
+	<version>1.0.0-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 
 	<description>
 		This is an "aggregator POM" and is not used in Maven inheritance.
-		It is not released and is simply a build helper.
-		This is an acceptable practice in Maven, use your favorite search engine to look it up.
+		It is simply a build helper.
 	</description>
+
+	<scm>
+		<url>https://github.com/bordertech/java-common</url>
+		<connection>scm:git:https://github.com/bordertech/java-common.git</connection>
+		<developerConnection>scm:git:https://github.com/bordertech/java-common.git</developerConnection>
+		<tag>java-common-1.0.0</tag>
+	</scm>
 
 	<modules>
 		<module>bordertech-parent</module>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -40,6 +40,13 @@
 					<linkXRef>false</linkXRef>
 					<includeTestSourceDirectory>false</includeTestSourceDirectory>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>com.github.bordertech.common</groupId>
+						<artifactId>build-tools</artifactId>
+						<version>1.0.3-SNAPSHOT</version>
+					</dependency>
+				</dependencies>
 				<executions>
 					<execution>
 						<id>checkStyle</id>
@@ -84,6 +91,13 @@
 					<threshold>Medium</threshold>
 					<excludeFilterFile>bordertech/findbugs-exclude-filter.xml</excludeFilterFile>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>com.github.bordertech.common</groupId>
+						<artifactId>build-tools</artifactId>
+						<version>1.0.3-SNAPSHOT</version>
+					</dependency>
+				</dependencies>
 				<executions>
 					<execution>
 						<id>checkFindbugs</id>
@@ -95,13 +109,5 @@
 				</executions>
 			</plugin>
 		</plugins>
-
-		<extensions>
-			<extension>
-				<groupId>com.github.bordertech.common</groupId>
-				<artifactId>build-tools</artifactId>
-				<version>1.0.3-SNAPSHOT</version>
-			</extension>
-		</extensions>
 	</build>
 </project>


### PR DESCRIPTION
The maven reactor did not calculate the correct module build order when dependencies between modules were declared in `<extensions>`. That's a shame because it allowed declaring the dependency once.

Instead each plugin now declares the dependency in a way the reactor will not ignore, ensuring correct build order.

Also, configured CI to simply ensure the project builds and not worry about the "no tests found" because you don't have unit tests in a project containing only POMs and resources.
