### PR TITLE
Update version of dependency-check-maven

### DIFF
--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -19,18 +19,17 @@
 		<findbugs.skip>${wc.qa.skip}</findbugs.skip>
 		<pmd.skip>${wc.qa.skip}</pmd.skip>
 		<badges.skip>${wc.qa.skip}</badges.skip>
+
 		<javadoc.excluded.packages />
 		<checkstyle.excludes />
 
 		<!--
 			OWASP dependency vulnerability scanner.
 		-->
-		<bt.owasp.dependency-check.version>3.3.2</bt.owasp.dependency-check.version>
-		<bt.owasp.dependency-check.enable>false</bt.owasp.dependency-check.enable>
-		<!-- properties to allow for mirroring of CVE definitions -->
-		<bt.owasp.dependency-check.cve.mirror>https://nvd.nist.gov/feeds/xml/cve</bt.owasp.dependency-check.cve.mirror>
-		<bt.owasp.dependency-check.cve.12.path>1.2</bt.owasp.dependency-check.cve.12.path>
-		<bt.owasp.dependency-check.cve.20.path>2.0</bt.owasp.dependency-check.cve.20.path>
+		<bt.owasp.dependency-check.version>4.0.1</bt.owasp.dependency-check.version>
+		<bt.owasp.dependency-check.skip>false</bt.owasp.dependency-check.skip>
+		<!-- allow for proxy settings -->
+		<bt.owasp.dependency-check.proxy></bt.owasp.dependency-check.proxy>
 		<!-- Non java analysers are off by default because, well this is a Maven builder! -->
 		<!-- nodejs nsp requires nsp on the path at scan time -->
 		<bt.owasp.dependency-check.enableNsp>false</bt.owasp.dependency-check.enableNsp>
@@ -60,10 +59,7 @@
 					<version>${bt.owasp.dependency-check.version}</version>
 					<configuration>
 						<failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
-						<cveUrl12Modified>${bt.owasp.dependency-check.cve.mirror}/${bt.owasp.dependency-check.cve.12.path}/nvdcve-Modified.xml.gz</cveUrl12Modified>
-						<cveUrl20Modified>${bt.owasp.dependency-check.cve.mirror}/${bt.owasp.dependency-check.cve.20.path}/nvdcve-2.0-Modified.xml.gz</cveUrl20Modified>
-						<cveUrl12Base>${bt.owasp.dependency-check.cve.mirror}/${bt.owasp.dependency-check.cve.12.path}/nvdcve-%d.xml.gz</cveUrl12Base>
-						<cveUrl20Base>${bt.owasp.dependency-check.cve.mirror}/${bt.owasp.dependency-check.cve.20.path}/nvdcve-2.0-%d.xml.gz</cveUrl20Base>
+						<mavenSettingsProxyId>${bt.owasp.dependency-check.proxy}</mavenSettingsProxyId>
 						<retireJsAnalyzerEnabled>${bt.owasp.dependency-check.enableRetireJs}</retireJsAnalyzerEnabled><!-- see https://github.com/jeremylong/DependencyCheck/issues/1467 before turning this on -->
 						<nspAnalyzerEnabled>${bt.owasp.dependency-check.enableNsp}</nspAnalyzerEnabled>
 						<nuspecAnalyzerEnabled>${bt.owasp.dependency-check.enableNuspec}</nuspecAnalyzerEnabled>
@@ -207,7 +203,7 @@
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
 				<configuration>
-					<skip>${bt.owasp.dependency-check.enable}</skip>
+					<skip>${bt.owasp.dependency-check.skip}</skip>
 				</configuration>
 				<executions>
 					<execution>
@@ -382,10 +378,6 @@
 						<configuration>
 							<skip>false</skip>
 							<failOnError>false</failOnError>
-							<cveUrl12Modified>${bt.owasp.dependency-check.cve.mirror}/${bt.owasp.dependency-check.cve.12.path}/nvdcve-Modified.xml.gz</cveUrl12Modified>
-							<cveUrl20Modified>${bt.owasp.dependency-check.cve.mirror}/${bt.owasp.dependency-check.cve.20.path}/nvdcve-2.0-Modified.xml.gz</cveUrl20Modified>
-							<cveUrl12Base>${bt.owasp.dependency-check.cve.mirror}/${bt.owasp.dependency-check.cve.12.path}/nvdcve-%d.xml.gz</cveUrl12Base>
-							<cveUrl20Base>${bt.owasp.dependency-check.cve.mirror}/${bt.owasp.dependency-check.cve.20.path}/nvdcve-2.0-%d.xml.gz</cveUrl20Base>
 							<retireJsAnalyzerEnabled>${bt.owasp.dependency-check.enableRetireJs}</retireJsAnalyzerEnabled><!-- see https://github.com/jeremylong/DependencyCheck/issues/1467 before turning this on -->
 							<nspAnalyzerEnabled>${bt.owasp.dependency-check.enableNsp}</nspAnalyzerEnabled>
 							<nuspecAnalyzerEnabled>${bt.owasp.dependency-check.enableNuspec}</nuspecAnalyzerEnabled>


### PR DESCRIPTION
 Change default config to  use an (undefined) proxy instead of a DB mirror. This is a more reliable way of ensuring the database is up to date.