### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
 # java-common
+
 Reusable build configuration for for BorderTech open source projects.
 
 ## Status
+
 [![Build Status](https://travis-ci.com/BorderTech/java-common.svg?branch=master)](https://travis-ci.com/BorderTech/java-common)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c7a2226acd574943af9ae966c54b05e6)](https://app.codacy.com/app/BorderTech/java-common?utm_source=github.com&utm_medium=referral&utm_content=BorderTech/java-common&utm_campaign=Badge_Grade_Dashboard)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.bordertech.common/bordertech-parent.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.github.bordertech.common%22%20AND%20a:%22bordertech-parent%22)
 
 ## qa-parent
+
 BorderTech java projects should generally use this as their parent POM.
 
 It runs quality assurance checks on your java code using tools such as checkstyle, pmd and findbugs.
 
 By default qa checks do not run, you must enable them on a per-module basis in the pom.xml like so:
 
-```xml
+``` xml
 <properties>
-	<!-- Set bt.qa.skip to false to run QA checks. -->
-	<bt.qa.skip>false</bt.qa.skip>
+  <!-- Set bt.qa.skip to false to run QA checks. -->
+  <bt.qa.skip>false</bt.qa.skip>
 </properties>
 ```
+
 Refer to qa-parent's [pom.xml](https://github.com/BorderTech/java-common/blob/master/qa-parent/pom.xml) for other project properties.
 
 The qa-parent inherits all of the release functionality from bordertech-parent, discussed below.
 
 ## bordertech-parent
+
 This is the top-level pom.xml file.
 It configures the maven release plugin for open source BorderTech projects to release to Maven Central.
 
@@ -31,9 +36,9 @@ _Note that java projects should generally not consume this directly but instead 
 
 Projects using this must ensure the necessary POM sections are overriden - these are marked in the bordertech-parent pom, for example:
 
-```xml
+``` xml
 <!--
-	Descendants SHOULD override the url.
+  Descendants SHOULD override the url.
 -->
 <url>https://github.com/bordertech/java-common/</url>
 ```
@@ -41,9 +46,11 @@ Projects using this must ensure the necessary POM sections are overriden - these
 Once you have configured your project and environment you can release to Maven Central. It may look a little something like the examples below.
 
 ### Releasing
+
 The golden rule is ALWAYS do the release on a separate branch (it makes [backing out](https://github.com/BorderTech/java-common/wiki/Releasing#dealing-with-failure) much easier when problems arise).
 
 Full documentation is available in the wiki under [Releasing](https://github.com/BorderTech/java-common/wiki/Releasing).
 
 ## build-tools
+
 This is primarily a shared resources module used by qa-parent and potentially other BorderTech maven modules.

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,12 @@
 						</goals>
 						<configuration>
 							<rules>
+								<requireMavenVersion>
+									<version>[3.3.9,)</version>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>[1.8,)</version>
+								</requireJavaVersion>
 								<requirePropertyDiverges>
 									<property>project.description</property>
 								</requirePropertyDiverges>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -80,7 +80,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.2</version>
+				<version>0.8.3</version>
 				<executions>
 					<!-- Prepare Jacoco agent. -->
 					<execution>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -61,7 +61,7 @@
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-engine</artifactId>
-				<version>5.3.2</version>
+				<version>5.4.0</version>
 				<scope>test</scope>
 			</dependency>
 			<!-- Junit 5 support for Junit 4 -->
@@ -69,7 +69,7 @@
 				<groupId>org.junit.vintage</groupId>
 				<artifactId>junit-vintage-engine</artifactId>
 				<scope>test</scope>
-				<version>5.3.2</version>
+				<version>5.4.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -125,7 +125,7 @@
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
-						<version>8.16</version>
+						<version>8.17</version>
 					</dependency>
 					<!-- Bordertech config -->
 					<dependency>
@@ -168,22 +168,22 @@
 					<dependency>
 						<groupId>net.sourceforge.pmd</groupId>
 						<artifactId>pmd-core</artifactId>
-						<version>6.10.0</version>
+						<version>6.11.0</version>
 					</dependency>
 					<dependency>
 						<groupId>net.sourceforge.pmd</groupId>
 						<artifactId>pmd-java</artifactId>
-						<version>6.10.0</version>
+						<version>6.11.0</version>
 					</dependency>
 					<dependency>
 						<groupId>net.sourceforge.pmd</groupId>
 						<artifactId>pmd-javascript</artifactId>
-						<version>6.10.0</version>
+						<version>6.11.0</version>
 					</dependency>
 					<dependency>
 						<groupId>net.sourceforge.pmd</groupId>
 						<artifactId>pmd-jsp</artifactId>
-						<version>6.10.0</version>
+						<version>6.11.0</version>
 					</dependency>
 					<!-- Bordertech config -->
 					<dependency>
@@ -219,7 +219,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>3.1.10</version>
+				<version>3.1.11</version>
 				<configuration>
 					<effort>Max</effort>
 					<failOnError>true</failOnError>
@@ -256,7 +256,7 @@
 					<dependency>
 						<groupId>com.github.spotbugs</groupId>
 						<artifactId>spotbugs</artifactId>
-						<version>3.1.10</version>
+						<version>3.1.11</version>
 					</dependency>
 					<!-- Bordertech config. -->
 					<dependency>
@@ -271,13 +271,12 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>4.0.2</version>
+				<version>5.0.0-M1</version>
 				<configuration>
 					<failBuildOnCVSS>${bt.owasp.fail.cvss.min}</failBuildOnCVSS>
 					<failBuildOnAnyVulnerability>${bt.owasp.fail.any}</failBuildOnAnyVulnerability>
 					<mavenSettingsProxyId>${bt.owasp.proxy.id}</mavenSettingsProxyId>
 					<retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled><!-- see https://github.com/jeremylong/DependencyCheck/issues/1467 before turning this on -->
-					<nspAnalyzerEnabled>false</nspAnalyzerEnabled>
 					<nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
 					<swiftPackageManagerAnalyzerEnabled>false</swiftPackageManagerAnalyzerEnabled>
 					<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>


### PR DESCRIPTION
* Updated versions on dependencies and plugins as per `mvn versions:show-dependency-updates` and  `mvn versions:show-plugin-updates`.
* Updated dependency-check-maven and removed (now) unsupported configuration option.
* Added a maven version check to the enforcer plugin as recommended by maven. This is necessary to get accurate plugin version reporting.
* Fixed a few minor markdown style issues in the readme.