### PR TITLE
Latest qa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Change log
+
+## Release in-progress
+* Add quick-build profile.
+* Update dependencies and plugin versions.
+* Update bt-checkstyle.xml to include latest checks from sun_check.xml.
+* Plugin configuration is only done via user properties which is easier for projects to override.
+
+## 1.0.15
+* Refactor README #52
+* Update plugin versions #54
+
+## 1.0.14
+* Update README.
+* Latest checkstyle and pmd.
+
+## 1.0.13
+* Remove redundant ${bt.plugin.xxxx} properties. Use plugin user properties instead.
+* Update QA override details in README.
+* Update bt-checkstyle.xml to include the latest checkstyle sun-check.xml changes.
+* Delete bt-spotbugs-exclude-filter.xml as projects should handle their own excludes.
+* Introduce ${bt.version} properties for dependency versions.
+* Introduce maven version checker to display updates for project dependencies.
+* Move enforce dependency convergence to qa-parent
+
+## 1.0.12
+* Updated plugin versions.
+* Enhance vulnerability checking.
+* Minor fixes to README.
+
+## 1.0.11
+* Update OWASP properties.
+
+## 1.0.10
+* Include dependency convergence check in the maven enforcer plugin.
+
+## 1.0.9
+* Fix Jacoco Coverage Report.
+
+## 1.0.8
+* Latest rules and versions of checkstyle, pmd and spotbugs (formerly findbugs).
+* Removed wc.qa.skip property to only use bt.qa.skip.
+* Removed surefire.version property as use plugin inheritance for version.
+* Upgrade to junit 5.
+
+## 1.0.7
+* Update version of dependency-check-maven and change default config.
+* Remove site generation.
+
+## 1.0.6
+* Added properties to manage non-java analysers in the dependency check plugin (see wiki).
+* Turned off the following analysers (in default configuration):
+  * nsp analyzer;
+  * nuspec analyzer;
+  * swift package manager analyzer; and
+  * assembly analyzer.
+* Incremented version of dependency-check-maven to 3.3.2.
+
+## 1.0.5
+* Added support for OWASP dependency checker using dependency-check-maven.
+
+## 1.0.4
+* Update README.
+* Added bt.qa.skip property.
+* Fix badger version.
+
+## 1.0.3
+* Added qa-parent.
+
+## 1.0.2
+* Generate javadoc and sources in release.
+
+## 1.0.1
+* Surefire version property.
+
+## 1.0.0
+* Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change log
 
 ## Release in-progress
-* Add quick-build profile.
+* Add quick-build profile that skips tests and QA checks #63
+* Change OWASP checker to fail on Critical (Level 9-10) issues and check for updates every 12 hours #60
 * Update dependencies and plugin versions.
-* Update bt-checkstyle.xml to include latest checks from sun_check.xml.
-* Plugin configuration is only done via user properties which is easier for projects to override.
+* Update bt-checkstyle.xml to include latest checks from checkstyle's sun_check.xml.
+* Plugin configuration is only done via user properties which is easier for projects to override #59
 
 ## 1.0.15
 * Refactor README #52

--- a/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
+++ b/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
@@ -18,6 +18,7 @@
   https://checkstyle.org (or in your downloaded distribution).
   Most Checks are configurable, be sure to consult the documentation.
   To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
   Finally, it is worth reading the documentation.
 -->
 
@@ -30,7 +31,8 @@
 	-->
 	<property name="severity" value="error"/>
 
-	<!-- BorderTech: Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation -->
+	<!-- BorderTech: Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation. -->
+	<!-- SuppressWarningsFilter and SuppressWarningsHolder have to be used together. -->
 	<module name="SuppressWarningsFilter" />
 
 	<!-- BorderTech: only check java files
@@ -66,22 +68,23 @@
 	<!-- Checks for Size Violations.                    -->
 	<!-- See https://checkstyle.org/config_sizes.html -->
 	<module name="FileLength">
-		<!-- Bordertech: override to warning -->
+		<!-- BorderTech: Override to warning -->
 		<property name="severity" value="warning" />
 	</module>
 	<module name="LineLength">
 		<property name="fileExtensions" value="java"/>
-		<!-- BorderTech: override from 80 to 150 -->
+		<!-- BorderTech: Override from 80 to 150 -->
 		<property name="max" value="150" />
-		<!-- Bordertech: override to warning -->
+		<!-- BorderTech: Override to warning -->
 		<property name="severity" value="warning" />
 	</module>
 
 	<!-- See https://checkstyle.org/config_whitespace.html -->
-	<!-- Bordetech: This check is removed as it fails if there are tabs
+	<!-- BorderTech: This check is removed as it fails if there are tabs
 	<module name="FileTabCharacter"/>
 	-->
-	<!-- Bordertech: Use tabs for indenting -->
+
+	<!-- BorderTech: Use tabs for indenting -->
 	<module name="RegexpSingleline">
 		<property name="format" value="^(\t*( +\t*(?! \*|\S))|(  ))"/>
 		<property name="message" value="Indentation should be tabs."/>
@@ -95,7 +98,7 @@
 		<property name="minimum" value="0"/>
 		<property name="maximum" value="0"/>
 		<property name="message" value="Line has trailing spaces."/>
-		<!-- Bordertech: override to warning -->
+		<!-- BorderTech: Override to warning -->
 		<property name="severity" value="warning" />
 	</module>
 
@@ -112,18 +115,19 @@
 		<property name="tabWidth" value="4"/>
 
 		<!-- BorderTech: Make the @SuppressWarnings annotations available to Checkstyle -->
+		<!-- SuppressWarningsFilter and SuppressWarningsHolder have to be used together. -->
 		<module name="SuppressWarningsHolder" />
 
 		<!-- Checks for Javadoc comments.                     -->
 		<!-- See https://checkstyle.org/config_javadoc.html -->
 		<module name="InvalidJavadocPosition"/>
 		<module name="JavadocMethod">
-			<!-- Bordertech: Javadoc not required for methods with these annotations -->
+			<!-- BorderTech: Javadoc not required for methods with these annotations -->
 			<property name="allowedAnnotations" value="Override,Test,Before,After,BeforeClass,AfterClass"/>
 		</module>
 		<module name="JavadocType"/>
 		<module name="JavadocVariable">
-			<!-- Bordertech: Push scope that is checked from private to protected -->
+			<!-- BorderTech: Push scope that is checked from private to protected -->
 			<property name="scope" value="protected"/>
 		</module>
 		<module name="JavadocStyle"/>
@@ -154,11 +158,11 @@
 		<!-- Checks for Size Violations.                    -->
 		<!-- See https://checkstyle.org/config_sizes.html -->
 		<module name="MethodLength">
-			<!-- Bordertech: override to warning -->
+			<!-- BorderTech: Override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="ParameterNumber">
-			<!-- Bordertech: override to warning -->
+			<!-- BorderTech: Override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 
@@ -182,7 +186,7 @@
 		<!-- See https://checkstyle.org/config_modifiers.html -->
 		<module name="ModifierOrder"/>
 		<module name="RedundantModifier">
-			<!-- Bordertech: override to warning -->
+			<!-- BorderTech: Override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 
@@ -193,7 +197,7 @@
 			<property name="allowInSwitchCase" value="true"/>
 		</module>
 		<module name="EmptyBlock">
-			<!-- Bordertech: override to warning -->
+			<!-- BorderTech: Override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="LeftCurly"/>
@@ -203,22 +207,30 @@
 		<!-- Checks for common coding problems               -->
 		<!-- See https://checkstyle.org/config_coding.html -->
 		<module name="EmptyStatement">
-			<!-- Bordertech: override to warning -->
+			<!-- BorderTech: Override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="EqualsHashCode"/>
 		<module name="HiddenField">
-			<!-- Bordertech: override to ignore -->
-			<property name="severity" value="ignore" />
+			<!-- BorderTech: Override from false for constructor parameters -->
+			<property name="ignoreConstructorParameter" value = "true" />
+			<!-- BorderTech: Override from false for setter parameters -->
+			<property name="ignoreSetter" value = "true" />
+			<!-- BorderTech: Override to warning -->
+			<property name="severity" value="warning" />
 		</module>
 		<module name="IllegalInstantiation"/>
 		<module name="InnerAssignment"/>
 		<module name="MagicNumber">
-			<!-- Bordertech: override to ignore -->
-			<property name="severity" value="ignore" />
+			<!-- BorderTech: Override from false for hash code methods -->
+			<property name="ignoreHashCodeMethod" value = "true" />
+			<!-- BorderTech: Override from false for annotation methods -->
+			<property name="ignoreAnnotation" value = "true" />
+			<!-- BorderTech: Override to warning -->
+			<property name="severity" value="warning" />
 		</module>
 		<module name="MissingSwitchDefault">
-			<!-- Bordertech: override to warning -->
+			<!-- BorderTech: Override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="MultipleVariableDeclarations"/>
@@ -238,11 +250,11 @@
 		<!-- Miscellaneous other checks.                   -->
 		<!-- See https://checkstyle.org/config_misc.html -->
 		<!--
-	   <module name="ArrayTypeStyle"/>
+		<module name="ArrayTypeStyle"/>
 		-->
 		<module name="FinalParameters"/>
 		<module name="TodoComment">
-			<!-- Bordertech: override to warning -->
+			<!-- BorderTech: Override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="UpperEll"/>

--- a/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
+++ b/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+		"https://checkstyle.org/dtds/configuration_1_3.dtd">
 
-<!-- Based on sun_checks.xml (V8.2) -->
+<!-- Based on sun_checks.xml (V8.30) -->
 
 <!--
   Checkstyle configuration that checks the sun coding conventions from:
@@ -15,7 +15,7 @@
 	- the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
 	- some best practices
   Checkstyle is very configurable. Be sure to read the documentation at
-  http://checkstyle.sourceforge.net (or in your downloaded distribution).
+  https://checkstyle.org (or in your downloaded distribution).
   Most Checks are configurable, be sure to consult the documentation.
   To completely disable a check, just comment it out or delete it from the file.
   Finally, it is worth reading the documentation.
@@ -28,12 +28,12 @@
 		https://checkstyle.org/5.x/config.html#Checker
 		<property name="basedir" value="${basedir}"/>
 	-->
+	<property name="severity" value="error"/>
 
-
-	<!-- BorderTech Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation -->
+	<!-- BorderTech: Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation -->
 	<module name="SuppressWarningsFilter" />
 
-	<!-- BorderTech
+	<!-- BorderTech: only check java files
 		<property name="fileExtensions" value="java, properties, xml"/>
 	-->
 	<property name="fileExtensions" value="java"/>
@@ -44,36 +44,44 @@
 		<property name="fileNamePattern" value="module\-info\.java$"/>
 	</module>
 
+	<!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+	<module name="SuppressionFilter">
+		<property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+				  default="checkstyle-suppressions.xml" />
+		<property name="optional" value="true"/>
+	</module>
+
 	<!-- Checks that a package-info.java file exists for each package.     -->
-	<!-- See http://checkstyle.sourceforge.net/config_javadoc.html#JavadocPackage -->
+	<!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
 	<module name="JavadocPackage"/>
 
 	<!-- Checks whether files end with a new line.                        -->
-	<!-- See http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile -->
-	<module name="NewlineAtEndOfFile">
-		<!-- BorderTech
-			Choosing "lf" should allow eof to be either "LF" or "CRLF" (both end with "LF").
-			This is more permissive and more predicatable than the default "enforce whatever line separator is default on the current platform".
-			When fetching code via git newlines are usually normalized anyway.
-		-->
-		<property name="lineSeparator" value="lf"/>
-	</module>
+	<!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+	<module name="NewlineAtEndOfFile"/>
 
 	<!-- Checks that property files contain the same keys.         -->
-	<!-- See http://checkstyle.sourceforge.net/config_misc.html#Translation -->
+	<!-- See https://checkstyle.org/config_misc.html#Translation -->
 	<module name="Translation"/>
 
 	<!-- Checks for Size Violations.                    -->
-	<!-- See http://checkstyle.sourceforge.net/config_sizes.html -->
+	<!-- See https://checkstyle.org/config_sizes.html -->
 	<module name="FileLength">
+		<!-- Bordertech: override to warning -->
+		<property name="severity" value="warning" />
+	</module>
+	<module name="LineLength">
+		<property name="fileExtensions" value="java"/>
+		<!-- BorderTech: override from 80 to 150 -->
+		<property name="max" value="150" />
+		<!-- Bordertech: override to warning -->
 		<property name="severity" value="warning" />
 	</module>
 
-	<!-- Checks for whitespace                               -->
-	<!-- See http://checkstyle.sourceforge.net/config_whitespace.html -->
-	<!--
+	<!-- See https://checkstyle.org/config_whitespace.html -->
+	<!-- Bordetech: This check is removed as it fails if there are tabs
 	<module name="FileTabCharacter"/>
 	-->
+	<!-- Bordertech: Use tabs for indenting -->
 	<module name="RegexpSingleline">
 		<property name="format" value="^(\t*( +\t*(?! \*|\S))|(  ))"/>
 		<property name="message" value="Indentation should be tabs."/>
@@ -81,41 +89,49 @@
 	</module>
 
 	<!-- Miscellaneous other checks.                   -->
-	<!-- See http://checkstyle.sourceforge.net/config_misc.html -->
+	<!-- See https://checkstyle.org/config_misc.html -->
 	<module name="RegexpSingleline">
 		<property name="format" value="\s+$"/>
-		<property name="maximum" value="10"/>
+		<property name="minimum" value="0"/>
+		<property name="maximum" value="0"/>
 		<property name="message" value="Line has trailing spaces."/>
+		<!-- Bordertech: override to warning -->
+		<property name="severity" value="warning" />
 	</module>
 
 	<!-- Checks for Headers                                -->
-	<!-- See http://checkstyle.sourceforge.net/config_header.html   -->
+	<!-- See https://checkstyle.org/config_header.html   -->
 	<!-- <module name="Header"> -->
 	<!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
 	<!--   <property name="fileExtensions" value="java"/> -->
 	<!-- </module> -->
 
 	<module name="TreeWalker">
-		<!-- BorderTech -->
+
+		<!-- BorderTech: Override for how many spaces a tab takes from 8 to 4 -->
 		<property name="tabWidth" value="4"/>
 
-		<!-- BorderTech Make the @SuppressWarnings annotations available to Checkstyle -->
+		<!-- BorderTech: Make the @SuppressWarnings annotations available to Checkstyle -->
 		<module name="SuppressWarningsHolder" />
 
 		<!-- Checks for Javadoc comments.                     -->
-		<!-- See http://checkstyle.sourceforge.net/config_javadoc.html -->
+		<!-- See https://checkstyle.org/config_javadoc.html -->
+		<module name="InvalidJavadocPosition"/>
 		<module name="JavadocMethod">
+			<!-- Bordertech: Javadoc not required for methods with these annotations -->
 			<property name="allowedAnnotations" value="Override,Test,Before,After,BeforeClass,AfterClass"/>
 		</module>
 		<module name="JavadocType"/>
 		<module name="JavadocVariable">
+			<!-- Bordertech: Push scope that is checked from private to protected -->
 			<property name="scope" value="protected"/>
 		</module>
 		<module name="JavadocStyle"/>
+		<module name="MissingJavadocMethod"/>
 
 		<!-- Checks for Naming Conventions.                  -->
-		<!-- See http://checkstyle.sourceforge.net/config_naming.html -->
-		<module name="ConstantName" />
+		<!-- See https://checkstyle.org/config_naming.html -->
+		<module name="ConstantName"/>
 		<module name="LocalFinalVariableName"/>
 		<module name="LocalVariableName"/>
 		<module name="MemberName"/>
@@ -123,39 +139,36 @@
 		<module name="PackageName"/>
 		<module name="ParameterName"/>
 		<module name="StaticVariableName"/>
-		<module name="TypeName" />
+		<module name="TypeName"/>
 
 		<!-- Checks for imports                              -->
-		<!-- See http://checkstyle.sourceforge.net/config_import.html -->
+		<!-- See https://checkstyle.org/config_import.html -->
 		<module name="AvoidStarImport"/>
 		<module name="IllegalImport"/> <!-- defaults to sun.* packages -->
 		<module name="RedundantImport"/>
 		<module name="UnusedImports">
-			<!-- BorderTech -->
+			<!-- BorderTech: Check javadoc as well -->
 			<property name="processJavadoc" value="true" />
 		</module>
 
 		<!-- Checks for Size Violations.                    -->
-		<!-- See http://checkstyle.sourceforge.net/config_sizes.html -->
-		<module name="LineLength">
-			<!-- BorderTech -->
-			<property name="max" value="150" />
-			<property name="severity" value="warning" />
-		</module>
+		<!-- See https://checkstyle.org/config_sizes.html -->
 		<module name="MethodLength">
+			<!-- Bordertech: override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="ParameterNumber">
+			<!-- Bordertech: override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 
 		<!-- Checks for whitespace                               -->
-		<!-- See http://checkstyle.sourceforge.net/config_whitespace.html -->
+		<!-- See https://checkstyle.org/config_whitespace.html -->
 		<module name="EmptyForIteratorPad"/>
 		<module name="GenericWhitespace"/>
 		<module name="MethodParamPad"/>
 		<module name="NoWhitespaceAfter">
-			<!-- BorderTech -->
+			<!-- BorderTech: Tokens to check -->
 			<property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
 		</module>
 		<module name="NoWhitespaceBefore"/>
@@ -166,19 +179,21 @@
 		<module name="WhitespaceAround"/>
 
 		<!-- Modifier Checks                                    -->
-		<!-- See http://checkstyle.sourceforge.net/config_modifiers.html -->
+		<!-- See https://checkstyle.org/config_modifiers.html -->
 		<module name="ModifierOrder"/>
 		<module name="RedundantModifier">
+			<!-- Bordertech: override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 
 		<!-- Checks for blocks. You know, those {}'s         -->
 		<!-- See http://checkstyle.sourceforge.net/config_blocks.html -->
 		<module name="AvoidNestedBlocks">
-			<!-- BorderTech -->
+			<!-- BorderTech: Allow a nested block in a switch -->
 			<property name="allowInSwitchCase" value="true"/>
 		</module>
 		<module name="EmptyBlock">
+			<!-- Bordertech: override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="LeftCurly"/>
@@ -186,24 +201,24 @@
 		<module name="RightCurly"/>
 
 		<!-- Checks for common coding problems               -->
-		<!-- See http://checkstyle.sourceforge.net/config_coding.html -->
-		<!-- BorderTech
-		<module name="AvoidInlineConditionals"/>
-		-->
+		<!-- See https://checkstyle.org/config_coding.html -->
 		<module name="EmptyStatement">
+			<!-- Bordertech: override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="EqualsHashCode"/>
 		<module name="HiddenField">
-			<!-- BorderTech -->
+			<!-- Bordertech: override to ignore -->
 			<property name="severity" value="ignore" />
 		</module>
 		<module name="IllegalInstantiation"/>
 		<module name="InnerAssignment"/>
 		<module name="MagicNumber">
+			<!-- Bordertech: override to ignore -->
 			<property name="severity" value="ignore" />
 		</module>
 		<module name="MissingSwitchDefault">
+			<!-- Bordertech: override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="MultipleVariableDeclarations"/>
@@ -211,8 +226,8 @@
 		<module name="SimplifyBooleanReturn"/>
 
 		<!-- Checks for class design                         -->
-		<!-- See http://checkstyle.sourceforge.net/config_design.html -->
-		<!-- BorderTech
+		<!-- See https://checkstyle.org/config_design.html -->
+		<!-- BorderTech: This check is specific for library projects (not applications)
 		<module name="DesignForExtension"/>
 		-->
 		<module name="FinalClass"/>
@@ -221,15 +236,23 @@
 		<module name="VisibilityModifier"/>
 
 		<!-- Miscellaneous other checks.                   -->
-		<!-- See http://checkstyle.sourceforge.net/config_misc.html -->
+		<!-- See https://checkstyle.org/config_misc.html -->
 		<!--
 	   <module name="ArrayTypeStyle"/>
 		-->
 		<module name="FinalParameters"/>
 		<module name="TodoComment">
+			<!-- Bordertech: override to warning -->
 			<property name="severity" value="warning" />
 		</module>
 		<module name="UpperEll"/>
+
+		<!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+		<module name="SuppressionXpathFilter">
+			<property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+					  default="checkstyle-xpath-suppressions.xml" />
+			<property name="optional" value="true"/>
+		</module>
 
 	</module>
 

--- a/build-tools/src/main/resources/bordertech/bt-pmd-rules.xml
+++ b/build-tools/src/main/resources/bordertech/bt-pmd-rules.xml
@@ -48,12 +48,10 @@
 		<priority>3</priority>
 	</rule>
 
-	<!-- Property override not working
 	<rule ref="category/java/documentation.xml/CommentRequired">
 		<properties>
-			<property name="fieldCommentRequirement">Ignored</property>
+			<property name="fieldCommentRequirement" value="Ignored"/>
 		</properties>
 	</rule>
-	-->
 
 </ruleset>

--- a/build-tools/src/main/resources/bordertech/bt-pmd-rules.xml
+++ b/build-tools/src/main/resources/bordertech/bt-pmd-rules.xml
@@ -11,6 +11,7 @@
 	</rule>
 	<rule ref="category/java/design.xml">
 		<exclude name="LawOfDemeter"/>
+		<exclude name="LoosePackageCoupling"/>
 	</rule>
 	<rule ref="category/java/documentation.xml">
 		<exclude name="CommentSize"/>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.2.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -186,7 +186,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M2</version>
+				<version>3.0.0-M3</version>
 				<executions>
 					<execution>
 						<id>enforcer</id>
@@ -236,7 +236,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>3.1.0</version>
+						<version>3.2.1</version>
 						<configuration>
 							<archive>
 								<manifestEntries>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -55,6 +55,7 @@
 		<failBuildOnCVSS>9</failBuildOnCVSS>
 		<!-- If set, owasp uses the proxy id in maven settings to download its db. -->
 		<mavenSettingsProxyId />
+		<!-- Disable analyzers -->
 		<!-- Disable retirejs analyzer -->
 		<retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
 		<!-- Disable swift analyzer -->
@@ -64,7 +65,7 @@
 		<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
 
 		<!-- Versions -->
-		<bt.junit.version>5.6.0</bt.junit.version>
+		<bt.junit.version>5.6.1</bt.junit.version>
 		<bt.jacoco.plugin.version>0.8.5</bt.jacoco.plugin.version>
 		<bt.surefire.plugin.version>2.22.2</bt.surefire.plugin.version>
 		<bt.checkstyle.plugin.version>3.1.1</bt.checkstyle.plugin.version>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -30,10 +30,15 @@
 		<!-- Config file -->
 		<checkstyle.config.location>bordertech/bt-checkstyle.xml</checkstyle.config.location>
 		<!-- PMD -->
+		<pmd.printFailingErrors>true</pmd.printFailingErrors>
 		<!-- Priority: 1 (High) - 5 (Low) -->
 		<pmd.failurePriority>2</pmd.failurePriority>
+		<!-- Print details of check failures to build output -->
+		<pmd.verbose>true</pmd.verbose>
 		<!-- Rules file -->
 		<bt.pmd.rules.file>bordertech/bt-pmd-rules.xml</bt.pmd.rules.file>
+		<!-- CPD (Default to report only) -->
+		<cpd.failOnViolation>false</cpd.failOnViolation>
 
 		<!-- Spotbugs -->
 		<!-- Effort -->
@@ -43,13 +48,20 @@
 		<!-- Rank: Scariest (1-4), Scary (5-9), Troubling (10-14), Of concern (15-20) -->
 		<spotbugs.maxRank>14</spotbugs.maxRank>
 
-		<!-- OWASP -->
+		<!-- OWASP (Default to Critical) -->
 		<!-- Check every 12 hours (default is 4) -->
 		<cveValidForHours>12</cveValidForHours>
 		<!-- Min cvss score to fail on. Range 0-10 : LOW: 0-3.9, MEDIUM: 4-6.9, HIGH: 7.0-8.9, Critical: 9.0-10.0 (Default is 11 which means it never fails) -->
-		<failBuildOnCVSS>4</failBuildOnCVSS>
+		<failBuildOnCVSS>9</failBuildOnCVSS>
 		<!-- If set, owasp uses the proxy id in maven settings to download its db. -->
 		<mavenSettingsProxyId />
+		<!-- Disable retirejs analyzer -->
+		<retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
+		<!-- Disable swift analyzer -->
+		<swiftPackageManagerAnalyzerEnabled>false</swiftPackageManagerAnalyzerEnabled>
+		<!-- Disbale .net analyzers -->
+		<nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
+		<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
 
 		<!-- Versions -->
 		<bt.junit.version>5.6.0</bt.junit.version>
@@ -130,11 +142,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>${bt.checkstyle.plugin.version}</version>
-				<configuration>
-					<failsOnError>true</failsOnError>
-					<linkXRef>false</linkXRef>
-					<consoleOutput>true</consoleOutput>
-				</configuration>
 				<dependencies>
 					<!-- Latest checkstyle version -->
 					<dependency>
@@ -169,9 +176,6 @@
 					<rulesets>
 						<ruleset>${bt.pmd.rules.file}</ruleset>
 					</rulesets>
-					<printFailingErrors>true</printFailingErrors>
-					<linkXRef>false</linkXRef>
-					<verbose>true</verbose>
 				</configuration>
 				<dependencies>
 					<!-- Latest pmd version -->
@@ -215,9 +219,6 @@
 					<execution>
 						<id>checkCpd</id>
 						<phase>verify</phase>
-						<configuration>
-							<failOnViolation>false</failOnViolation>
-						</configuration>
 						<goals>
 							<goal>cpd-check</goal>
 						</goals>
@@ -276,12 +277,6 @@
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
 				<version>${bt.owasp.plugin.version}</version>
-				<configuration>
-					<retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
-					<nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
-					<swiftPackageManagerAnalyzerEnabled>false</swiftPackageManagerAnalyzerEnabled>
-					<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-				</configuration>
 				<executions>
 					<execution>
 						<id>checkDependencies</id>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -86,6 +86,31 @@
 		configuration from bordertech-parent.
 	</description>
 
+	<profiles>
+		<!-- Quick build profile with testing and QA turned off -->
+		<profile>
+			<id>quick-build</id>
+			<properties>
+				<!-- Skip tests -->
+				<skipTests>true</skipTests>
+				<jacoco.skip>true</jacoco.skip>
+				<!-- Skip QA -->
+				<bt.qa.skip>true</bt.qa.skip>
+				<!-- Skip each plugin individually to handle projects that have set bt.qa.skip to false -->
+				<checkstyle.skip>true</checkstyle.skip>
+				<pmd.skip>true</pmd.skip>
+				<cpd.skip>true</cpd.skip>
+				<spotbugs.skip>true</spotbugs.skip>
+				<!-- Skip OWASP -->
+				<dependency-check.skip>true</dependency-check.skip>
+				<!-- Skip enforcer -->
+				<enforcer.skip>true</enforcer.skip>
+				<!-- Skip javadoc -->
+				<maven.javadoc.skip>true</maven.javadoc.skip>
+			</properties>
+		</profile>
+	</profiles>
+
 	<dependencyManagement>
 		<dependencies>
 			<!-- Junit 5 -->

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -52,18 +52,18 @@
 		<mavenSettingsProxyId />
 
 		<!-- Versions -->
-		<bt.junit.version>5.5.0</bt.junit.version>
-		<bt.jacoco.plugin.version>0.8.4</bt.jacoco.plugin.version>
+		<bt.junit.version>5.6.0</bt.junit.version>
+		<bt.jacoco.plugin.version>0.8.5</bt.jacoco.plugin.version>
 		<bt.surefire.plugin.version>2.22.2</bt.surefire.plugin.version>
-		<bt.checkstyle.plugin.version>3.0.0</bt.checkstyle.plugin.version>
-		<bt.checkstyle.version>8.22</bt.checkstyle.version>
-		<bt.pmd.plugin.version>3.12.0</bt.pmd.plugin.version>
-		<bt.pmd.version>6.16.0</bt.pmd.version>
-		<bt.spotbugs.plugin.version>3.1.11</bt.spotbugs.plugin.version>
-		<bt.fb-contrib.plugin.version>7.4.5</bt.fb-contrib.plugin.version>
-		<bt.spotbugs.version>3.1.12</bt.spotbugs.version>
-		<bt.findsecbugs.plugin.version>1.9.0</bt.findsecbugs.plugin.version>
-		<bt.owasp.plugin.version>5.0.0-M3</bt.owasp.plugin.version>
+		<bt.checkstyle.plugin.version>3.1.1</bt.checkstyle.plugin.version>
+		<bt.checkstyle.version>8.30</bt.checkstyle.version>
+		<bt.pmd.plugin.version>3.13.0</bt.pmd.plugin.version>
+		<bt.pmd.version>6.22.0</bt.pmd.version>
+		<bt.spotbugs.plugin.version>4.0.0</bt.spotbugs.plugin.version>
+		<bt.fb-contrib.plugin.version>7.4.7</bt.fb-contrib.plugin.version>
+		<bt.spotbugs.version>4.0.1</bt.spotbugs.version>
+		<bt.findsecbugs.plugin.version>1.10.1</bt.findsecbugs.plugin.version>
+		<bt.owasp.plugin.version>5.2.4</bt.owasp.plugin.version>
 
 	</properties>
 


### PR DESCRIPTION
- Add quick-build profile that skips tests and QA checks. Closes #63
- Change OWASP checker to fail on Critical (Level 9-10) issues and check for updates every 12 hours. Closes #60
- Plugin configuration is only done via user properties which is easier for projects to override. Closes #59
- Update dependencies and plugin versions.
- Update bt-checkstyle.xml to include latest checks from checkstyle's sun_check.xml.
- Add change log
