### PR TITLE
Enforcer Convergence and OWASP updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## Release in-progress
+* Update OWASP plugin skip property default to use bt.qa.skip #79
 * Move enforcer convergence check into verify phase. Can be skipped using bt.convergence.check.skip=true property. #78
 * Move versions-maven-plugin into a profile display-versions to allow projects to opt in or out #74
 * Switch from travis-ci to GitHub Actions #75

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## Release in-progress
+* Move enforcer convergence check into verify phase. Can be skipped using bt.convergence.check.skip=true property. #78
 * Move versions-maven-plugin into a profile display-versions to allow projects to opt in or out #74
 * Switch from travis-ci to GitHub Actions #75
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ The qa-parent runs quality assurance checks on your java code using tools such a
   - the [Checkstyle plugin](https://maven.apache.org/plugins/maven-checkstyle-plugin) to check the code style used by the developers
   - the [PMD plugin](https://maven.apache.org/plugins/maven-pmd-plugin) for source code analysis
   - the [Spotbugs plugin](https://spotbugs.github.io/spotbugs-maven-plugin) that looks for bugs in Java programs using bug patterns
-
-The qa-parent also runs:
   - the [OWASP plugin](https://jeremylong.github.io/DependencyCheck/dependency-check-maven/index.html) to check security vulnerabilities
   - the [Enforcer plugin](https://maven.apache.org/enforcer/maven-enforcer-plugin/) to check dependency convergence
+
+The qa-parent also runs:
   - the [JaCoCo plugin](https://www.eclemma.org/jacoco/trunk/doc/maven.html) for code coverage reports
   - the [Surefire plugin](https://maven.apache.org/surefire/maven-surefire-plugin) for running unit tests
 
@@ -106,6 +106,8 @@ The qa-parent provides a profile `quick-build` that for convenience skips all te
 #### display-versions profile
 
 The qa-parent provides a profile `display-versions` that uses the [Version checker plugin](https://www.mojohaus.org/versions-maven-plugin/) to report project dependencies that have new versions.
+
+Refer to [Version checker plugin](https://www.mojohaus.org/versions-maven-plugin/) for all override details.
 
 ### build-tools
 
@@ -136,13 +138,12 @@ Refer to the plugin sections below for basic override details:
   - [Spotbugs plugin](#spotbugs)
   - [OWASP plugin](#owasp)
   - [Enforcer plugin](#enforcer-plugin)
-  - [Version checker plugin](#version-checker)
   - [JaCoCo plugin](#jacoco)
   - [Surefire plugin](#surefire)
 
-#### Enable Static Analysis
+#### Enable Quality Checks
 
-By default qa checks (i.e. Checkstyle, PMD and Spotbugs) do not run, you must enable them on a per-module basis or the project parent pom:
+By default qa checks (i.e. Checkstyle, PMD, Spotbugs, OWASP, Convergence Check) do not run, you must enable them on a per-module basis or the project parent pom:
 
 ``` xml
 <property>
@@ -342,11 +343,11 @@ Updating the OWASP vulnerability database can also be blocked by the PROXY block
 
 Refer to [enforcer plugin](https://maven.apache.org/enforcer/maven-enforcer-plugin) for all override details.
 
-##### Skip enforcer
+##### Skip enforcer convergence check
 
 ``` xml
 <property>
-  <enforcer.skip>true</enforcer.skip>
+  <bt.convergence.check.skip>true</bt.convergence.check.skip>
 </property>
 ```
 
@@ -357,9 +358,6 @@ Refer to [enforcer plugin](https://maven.apache.org/enforcer/maven-enforcer-plug
   <enforcer.fail>false</enforcer.fail>
 </property>
 ```
-#### Version checker
-
-Refer to [Version checker plugin](https://www.mojohaus.org/versions-maven-plugin/) for all override details.
 
 #### JaCoCo
 

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -21,6 +21,7 @@
 		<pmd.skip>${bt.qa.skip}</pmd.skip>
 		<cpd.skip>${bt.qa.skip}</cpd.skip>
 		<spotbugs.skip>${bt.qa.skip}</spotbugs.skip>
+		<dependency-check.skip>${bt.qa.skip}</dependency-check.skip>
 		<bt.convergence.check.skip>${bt.qa.skip}</bt.convergence.check.skip>
 
 		<!--

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -21,6 +21,7 @@
 		<pmd.skip>${bt.qa.skip}</pmd.skip>
 		<cpd.skip>${bt.qa.skip}</cpd.skip>
 		<spotbugs.skip>${bt.qa.skip}</spotbugs.skip>
+		<bt.convergence.check.skip>${bt.qa.skip}</bt.convergence.check.skip>
 
 		<!--
 		These plugin settings are set as properties instead of being included in the default configuration to make it easier for projects to override.
@@ -104,8 +105,8 @@
 				<spotbugs.skip>true</spotbugs.skip>
 				<!-- Skip OWASP -->
 				<dependency-check.skip>true</dependency-check.skip>
-				<!-- Skip enforcer -->
-				<enforcer.skip>true</enforcer.skip>
+				<!-- Skip convergence check -->
+				<bt.convergence.check.skip>true</bt.convergence.check.skip>
 				<!-- Skip javadoc -->
 				<maven.javadoc.skip>true</maven.javadoc.skip>
 			</properties>
@@ -343,13 +344,14 @@
 				</executions>
 			</plugin>
 
-			<!-- Enforcer - Dependency Convergence -->
+			<!-- Verify: Enforcer check for Dependency Convergence -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>enforcer</id>
+						<id>enforcer-convergence-check</id>
+						<phase>verify</phase>
 						<goals>
 							<goal>enforce</goal>
 						</goals>
@@ -357,6 +359,8 @@
 							<rules>
 								<dependencyConvergence />
 							</rules>
+							<!-- Use a different skip property to not override and skip the enforcer plugin in bordertech_parent. -->
+							<skip>${bt.convergence.check.skip}</skip>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
* Update OWASP plugin skip property default to use bt.qa.skip #79
* Move enforcer convergence check into verify phase. Can be skipped using bt.convergence.check.skip=true property #78
