### PR TITLE
bt.qa.fail property and latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release in-progress
 * Added bt.qa.fail property as a convenience property to allow projects to fail builds or only report QA violations. #84
 * Added bt.convergence.check.fail property to allow the convergence check to be set to fail without overriding the enforcer plugin in bordertech_parent. #84
+* Update PMD and Checkstyle to latest versions
 
 ## 1.0.18
 * Default QA plugins to ignore generated code #61

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ## Release in-progress
+* Added bt.qa.fail property as a convenience property to allow projects to fail builds or only report QA violations. #84
+* Added bt.convergence.check.fail property to allow the convergence check to be set to fail without overriding the enforcer plugin in bordertech_parent. #84
 
 ## 1.0.18
 * Default QA plugins to ignore generated code #61

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ By default qa checks do not run, you must enable them on a per-module basis or i
 </property>
 ```
 
+The qa-parent default is to fail the build if QA violations are found. This can be overridden by setting the following property:
+
+``` xml
+<property>
+  <bt.qa.fail>false</bt.qa.fail>
+</property>
+```
+
 Use the following to run the qa-parent verification:
 
 ``` java
@@ -148,6 +156,16 @@ By default qa checks (i.e. Checkstyle, PMD, Spotbugs, OWASP, Convergence Check) 
 ``` xml
 <property>
   <bt.qa.skip>false</bt.qa.skip>
+</property>
+```
+
+#### Failing Build with QA Violations
+
+The qa-parent default is to fail the build if QA violations are found. This can be overridden by setting the following property:
+
+``` xml
+<property>
+  <bt.qa.fail>false</bt.qa.fail>
 </property>
 ```
 
@@ -392,7 +410,7 @@ Refer to [enforcer plugin](https://maven.apache.org/enforcer/maven-enforcer-plug
 
 ``` xml
 <property>
-  <enforcer.fail>false</enforcer.fail>
+  <bt.convergence.check.fail>false</bt.convergence.check.fail>
 </property>
 ```
 

--- a/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
+++ b/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
@@ -3,7 +3,7 @@
 		"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
 		"https://checkstyle.org/dtds/configuration_1_3.dtd">
 
-<!-- Based on sun_checks.xml V9.2.1 (https://github.com/checkstyle/checkstyle/blob/checkstyle-9.2.1/src/main/resources/sun_checks.xml) -->
+<!-- Based on sun_checks.xml V9.3 (https://github.com/checkstyle/checkstyle/blob/checkstyle-9.3/src/main/resources/sun_checks.xml) -->
 
 <!--
 Checkstyle configuration that checks the sun coding conventions from:

--- a/build-tools/src/main/resources/bordertech/bt-pmd-rules.xml
+++ b/build-tools/src/main/resources/bordertech/bt-pmd-rules.xml
@@ -27,6 +27,9 @@
 	<rule ref="category/java/codestyle.xml/ClassNamingConventions" >
 		<priority>3</priority>
 	</rule>
+	<rule ref="category/java/codestyle.xml/FinalParameterInAbstractMethod" >
+		<priority>3</priority>
+	</rule>
 	<rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod">
 		<priority>3</priority>
 	</rule>

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
 		Descendants outside the java-common project SHOULD override this section.
 	-->
 	<ciManagement>
-		<system>Travis CI</system>
-		<url>https://travis-ci.com/BorderTech/java-common</url>
+		<system>Github Actions</system>
+		<url>https://github.com/BorderTech/java-common/actions</url>
 	</ciManagement>
 
 	<!-- developers is a required section for Maven Central -->

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -24,6 +24,18 @@
 		<dependency-check.skip>${bt.qa.skip}</dependency-check.skip>
 		<bt.convergence.check.skip>${bt.qa.skip}</bt.convergence.check.skip>
 
+		<!-- FAIL QA -->
+		<bt.qa.fail>true</bt.qa.fail>
+		<checkstyle.failOnViolation>${bt.qa.fail}</checkstyle.failOnViolation>
+		<pmd.failOnViolation>${bt.qa.fail}</pmd.failOnViolation>
+		<spotbugs.failOnError>${bt.qa.fail}</spotbugs.failOnError>
+		<!-- OWASP -->
+		<failOnError>${bt.qa.fail}</failOnError>
+		<!-- Convergence Check -->
+		<bt.convergence.check.fail>${bt.qa.fail}</bt.convergence.check.fail>
+		<!-- CPD (Default to report only) -->
+		<cpd.failOnViolation>false</cpd.failOnViolation>
+
 		<!--
 		These plugin settings are set as properties instead of being included in the default configuration to make it easier for projects to override.
 		Property values are ignored if a default value is set in a configuation.
@@ -43,8 +55,6 @@
 		<bt.pmd.rules.file>bordertech/bt-pmd-rules.xml</bt.pmd.rules.file>
 		<!-- Override default to only use main src (ignore generated) -->
 		<bt.pmd.src>${project.build.sourceDirectory}</bt.pmd.src>
-		<!-- CPD (Default to report only) -->
-		<cpd.failOnViolation>false</cpd.failOnViolation>
 
 		<!-- Spotbugs -->
 		<!-- Effort -->
@@ -375,8 +385,9 @@
 							<rules>
 								<dependencyConvergence />
 							</rules>
-							<!-- Use a different skip property to not override and skip the enforcer plugin in bordertech_parent. -->
+							<!-- Use a different skip and fail property to not override the enforcer plugin in bordertech_parent. -->
 							<skip>${bt.convergence.check.skip}</skip>
+							<fail>${bt.convergence.check.fail}</fail>
 						</configuration>
 					</execution>
 				</executions>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -90,9 +90,9 @@
 		<bt.jacoco.plugin.version>0.8.7</bt.jacoco.plugin.version>
 		<bt.surefire.plugin.version>2.22.2</bt.surefire.plugin.version>
 		<bt.checkstyle.plugin.version>3.1.2</bt.checkstyle.plugin.version>
-		<bt.checkstyle.version>9.2.1</bt.checkstyle.version>
+		<bt.checkstyle.version>9.3</bt.checkstyle.version>
 		<bt.pmd.plugin.version>3.15.0</bt.pmd.plugin.version>
-		<bt.pmd.version>6.41.0</bt.pmd.version>
+		<bt.pmd.version>6.42.0</bt.pmd.version>
 		<bt.spotbugs.plugin.version>4.5.3.0</bt.spotbugs.plugin.version>
 		<bt.sb-contrib.plugin.version>7.4.7</bt.sb-contrib.plugin.version>
 		<bt.spotbugs.version>4.5.3</bt.spotbugs.version>


### PR DESCRIPTION
* Added bt.qa.fail property as a convenience property to allow projects to fail builds or only report QA violations. #84
* Added bt.convergence.check.fail property to allow the convergence check to be set to fail without overriding the enforcer plugin in bordertech_parent. #84
* Update PMD and Checkstyle to latest versions