### PR TITLE
Latest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release in-progress
 * Update plugin dependencies in bordertech_parent
+* Update plugin dependencies in qa_parent
 
 ## 1.0.19
 * Added bt.qa.fail property as a convenience property to allow projects to fail builds or only report QA violations. #84

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## Release in-progress
+* Update plugin dependencies in bordertech_parent
 
 ## 1.0.19
 * Added bt.qa.fail property as a convenience property to allow projects to fail builds or only report QA violations. #84

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Changed JavadocPackage check to warning
   * Changed EmptyForIteratorPad check to warning as IntelliJ code formatting does not currently allow for this
 * Added a new checkstyle config file bt-checkstyle-format-only.xml for projects that only want to check basic code formatting.
+* Modified the jacoco report goal to the test phase and to make sure it runs after surefire, moved the jacoco plugin after the surefire plugin in the pom file which is how maven determines the run order of plugins defined on the same phase #88
 
 ## 1.0.19
 * Added bt.qa.fail property as a convenience property to allow projects to fail builds or only report QA violations. #84

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Release in-progress
 * Update plugin dependencies in bordertech_parent
 * Update plugin dependencies in qa_parent
+* Made the following modifications to CheckStyle config file bt-checkstyle.xml:
+  * Moved tabWidth override to the top level checker element
+  * Changed tab indention check to no longer allow any violations by removing the maximum property which was set to 10
+  * Changed JavadocPackage check to warning
+  * Changed EmptyForIteratorPad check to warning as IntelliJ code formatting does not currently allow for this
 
 ## 1.0.19
 * Added bt.qa.fail property as a convenience property to allow projects to fail builds or only report QA violations. #84

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Changed tab indention check to no longer allow any violations by removing the maximum property which was set to 10
   * Changed JavadocPackage check to warning
   * Changed EmptyForIteratorPad check to warning as IntelliJ code formatting does not currently allow for this
+* Added a new checkstyle config file bt-checkstyle-format-only.xml for projects that only want to check basic code formatting.
 
 ## 1.0.19
 * Added bt.qa.fail property as a convenience property to allow projects to fail builds or only report QA violations. #84

--- a/build-tools/src/main/resources/bordertech/bt-checkstyle-format-only.xml
+++ b/build-tools/src/main/resources/bordertech/bt-checkstyle-format-only.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+"https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!-- This checkstyle file is setup just for code format rules. It has been extracted from the code style rules from bt-checkstyle. -->
+
+<module name="Checker">
+
+	<property name="severity" value="error"/>
+
+	<!-- BorderTech: Override for how many spaces a tab takes from 8 to 4 when Checkstyle prints messages. -->
+	<property name="tabWidth" value="4"/>
+
+	<!-- BorderTech: Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation. -->
+	<!-- SuppressWarningsFilter and SuppressWarningsHolder have to be used together. -->
+	<module name="SuppressWarningsFilter"/>
+
+	<!-- BorderTech: only check java files
+					<property name="fileExtensions" value="java, properties, xml"/>
+	-->
+	<property name="fileExtensions" value="java"/>
+
+	<!-- Excludes all 'module-info.java' files              -->
+	<!-- See https://checkstyle.org/config_filefilters.html -->
+	<module name="BeforeExecutionExclusionFileFilter">
+		<property name="fileNamePattern" value="module\-info\.java$"/>
+	</module>
+
+	<!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+	<module name="SuppressionFilter">
+		<property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+				  default="checkstyle-suppressions.xml"/>
+		<property name="optional" value="true"/>
+	</module>
+
+	<!-- Checks whether files end with a new line.                        -->
+	<!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+	<module name="NewlineAtEndOfFile"/>
+
+	<!-- Checks for Size Violations.                    -->
+	<!-- See https://checkstyle.org/config_sizes.html -->
+	<module name="FileLength">
+		<!-- BorderTech: Override to warning -->
+		<property name="severity" value="warning"/>
+	</module>
+	<module name="LineLength">
+		<property name="fileExtensions" value="java"/>
+		<!-- BorderTech: Override from 80 to 150 -->
+		<property name="max" value="150"/>
+		<!-- BorderTech: Override to warning -->
+		<property name="severity" value="warning"/>
+	</module>
+
+	<!-- BorderTech: Use tabs for indenting -->
+	<module name="RegexpSingleline">
+		<property name="format" value="^(\t*( +\t*(?! \*|\S))|(  ))"/>
+		<property name="message" value="Indentation should be tabs."/>
+	</module>
+
+	<!-- Miscellaneous other checks.                   -->
+	<!-- See https://checkstyle.org/config_misc.html -->
+	<module name="RegexpSingleline">
+		<property name="format" value="\s+$"/>
+		<property name="minimum" value="0"/>
+		<property name="maximum" value="0"/>
+		<property name="message" value="Line has trailing spaces."/>
+		<!-- BorderTech: Override to warning -->
+		<property name="severity" value="warning"/>
+	</module>
+
+	<module name="TreeWalker">
+
+		<!-- BorderTech: Make the @SuppressWarnings annotations available to Checkstyle -->
+		<!-- SuppressWarningsFilter and SuppressWarningsHolder have to be used together. -->
+		<module name="SuppressWarningsHolder"/>
+
+		<!-- Checks for imports                              -->
+		<!-- See https://checkstyle.org/config_imports.html -->
+		<module name="AvoidStarImport"/>
+		<module name="IllegalImport">
+			<!-- BorderTech: Override to warning as focusing on formatting issues -->
+			<property name="severity" value="warning"/>
+		</module><!-- defaults to sun.* packages -->
+		<module name="RedundantImport"/>
+		<module name="UnusedImports">
+			<!-- BorderTech: Check javadoc as well -->
+			<property name="processJavadoc" value="true"/>
+		</module>
+
+		<!-- Checks for whitespace                               -->
+		<!-- See https://checkstyle.org/config_whitespace.html -->
+		<module name="EmptyForIteratorPad">
+			<!-- BorderTech: Override to warning as IntelliJ does not currently allow for this-->
+			<property name="severity" value="warning"/>
+		</module>
+		<module name="GenericWhitespace"/>
+		<module name="MethodParamPad"/>
+		<module name="NoWhitespaceAfter">
+			<!-- BorderTech: Tokens to check -->
+			<property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+		</module>
+		<module name="NoWhitespaceBefore"/>
+		<module name="OperatorWrap"/>
+		<module name="ParenPad"/>
+		<module name="TypecastParenPad"/>
+		<module name="WhitespaceAfter"/>
+		<module name="WhitespaceAround"/>
+
+		<!-- Checks for blocks. You know, those {}'s         -->
+		<!-- See http://checkstyle.sourceforge.net/config_blocks.html -->
+		<module name="AvoidNestedBlocks">
+			<!-- BorderTech: Allow a nested block in a switch -->
+			<property name="allowInSwitchCase" value="true"/>
+		</module>
+		<module name="EmptyBlock">
+			<!-- BorderTech: Override to warning -->
+			<property name="severity" value="warning"/>
+		</module>
+		<module name="LeftCurly"/>
+		<module name="NeedBraces"/>
+		<module name="RightCurly"/>
+
+	</module>
+
+</module>

--- a/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
+++ b/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
@@ -3,7 +3,7 @@
 		"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
 		"https://checkstyle.org/dtds/configuration_1_3.dtd">
 
-<!-- Based on sun_checks.xml V9.3 (https://github.com/checkstyle/checkstyle/blob/checkstyle-9.3/src/main/resources/sun_checks.xml) -->
+<!-- Based on sun_checks.xml V10.7.0 (https://github.com/checkstyle/checkstyle/blob/checkstyle-10.7.0/src/main/resources/sun_checks.xml) -->
 
 <!--
 Checkstyle configuration that checks the sun coding conventions from:

--- a/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
+++ b/build-tools/src/main/resources/bordertech/bt-checkstyle.xml
@@ -31,9 +31,12 @@ Checkstyle configuration that checks the sun coding conventions from:
 	-->
 	<property name="severity" value="error"/>
 
+	<!-- BorderTech: Override for how many spaces a tab takes from 8 to 4 when Checkstyle prints messages. -->
+	<property name="tabWidth" value="4"/>
+
 	<!-- BorderTech: Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation. -->
 	<!-- SuppressWarningsFilter and SuppressWarningsHolder have to be used together. -->
-	<module name="SuppressWarningsFilter" />
+	<module name="SuppressWarningsFilter"/>
 
 	<!-- BorderTech: only check java files
 		<property name="fileExtensions" value="java, properties, xml"/>
@@ -49,13 +52,16 @@ Checkstyle configuration that checks the sun coding conventions from:
 	<!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
 	<module name="SuppressionFilter">
 		<property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
-				  default="checkstyle-suppressions.xml" />
+				  default="checkstyle-suppressions.xml"/>
 		<property name="optional" value="true"/>
 	</module>
 
 	<!-- Checks that a package-info.java file exists for each package.     -->
 	<!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
-	<module name="JavadocPackage"/>
+	<module name="JavadocPackage">
+		<!-- BorderTech: Override to warning -->
+		<property name="severity" value="warning"/>
+	</module>
 
 	<!-- Checks whether files end with a new line.                        -->
 	<!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
@@ -69,14 +75,14 @@ Checkstyle configuration that checks the sun coding conventions from:
 	<!-- See https://checkstyle.org/config_sizes.html -->
 	<module name="FileLength">
 		<!-- BorderTech: Override to warning -->
-		<property name="severity" value="warning" />
+		<property name="severity" value="warning"/>
 	</module>
 	<module name="LineLength">
 		<property name="fileExtensions" value="java"/>
 		<!-- BorderTech: Override from 80 to 150 -->
-		<property name="max" value="150" />
+		<property name="max" value="150"/>
 		<!-- BorderTech: Override to warning -->
-		<property name="severity" value="warning" />
+		<property name="severity" value="warning"/>
 	</module>
 
 	<!-- See https://checkstyle.org/config_whitespace.html -->
@@ -88,7 +94,6 @@ Checkstyle configuration that checks the sun coding conventions from:
 	<module name="RegexpSingleline">
 		<property name="format" value="^(\t*( +\t*(?! \*|\S))|(  ))"/>
 		<property name="message" value="Indentation should be tabs."/>
-		<property name="maximum" value="10"/>
 	</module>
 
 	<!-- Miscellaneous other checks.                   -->
@@ -99,7 +104,7 @@ Checkstyle configuration that checks the sun coding conventions from:
 		<property name="maximum" value="0"/>
 		<property name="message" value="Line has trailing spaces."/>
 		<!-- BorderTech: Override to warning -->
-		<property name="severity" value="warning" />
+		<property name="severity" value="warning"/>
 	</module>
 
 	<!-- Checks for Headers                                -->
@@ -111,18 +116,15 @@ Checkstyle configuration that checks the sun coding conventions from:
 
 	<module name="TreeWalker">
 
-		<!-- BorderTech: Override for how many spaces a tab takes from 8 to 4 -->
-		<property name="tabWidth" value="4"/>
-
 		<!-- BorderTech: Make the @SuppressWarnings annotations available to Checkstyle -->
 		<!-- SuppressWarningsFilter and SuppressWarningsHolder have to be used together. -->
-		<module name="SuppressWarningsHolder" />
+		<module name="SuppressWarningsHolder"/>
 
 		<!-- Checks for Javadoc comments.                     -->
 		<!-- See https://checkstyle.org/config_javadoc.html -->
 		<module name="InvalidJavadocPosition">
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 
 		<module name="JavadocMethod">
@@ -156,23 +158,26 @@ Checkstyle configuration that checks the sun coding conventions from:
 		<module name="RedundantImport"/>
 		<module name="UnusedImports">
 			<!-- BorderTech: Check javadoc as well -->
-			<property name="processJavadoc" value="true" />
+			<property name="processJavadoc" value="true"/>
 		</module>
 
 		<!-- Checks for Size Violations.                    -->
 		<!-- See https://checkstyle.org/config_sizes.html -->
 		<module name="MethodLength">
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 		<module name="ParameterNumber">
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 
 		<!-- Checks for whitespace                               -->
 		<!-- See https://checkstyle.org/config_whitespace.html -->
-		<module name="EmptyForIteratorPad"/>
+		<module name="EmptyForIteratorPad">
+			<!-- BorderTech: Override to warning as IntelliJ does not currently allow for this-->
+			<property name="severity" value="warning"/>
+		</module>
 		<module name="GenericWhitespace"/>
 		<module name="MethodParamPad"/>
 		<module name="NoWhitespaceAfter">
@@ -191,7 +196,7 @@ Checkstyle configuration that checks the sun coding conventions from:
 		<module name="ModifierOrder"/>
 		<module name="RedundantModifier">
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 
 		<!-- Checks for blocks. You know, those {}'s         -->
@@ -202,7 +207,7 @@ Checkstyle configuration that checks the sun coding conventions from:
 		</module>
 		<module name="EmptyBlock">
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 		<module name="LeftCurly"/>
 		<module name="NeedBraces"/>
@@ -212,30 +217,30 @@ Checkstyle configuration that checks the sun coding conventions from:
 		<!-- See https://checkstyle.org/config_coding.html -->
 		<module name="EmptyStatement">
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 		<module name="EqualsHashCode"/>
 		<module name="HiddenField">
 			<!-- BorderTech: Override from false for constructor parameters -->
-			<property name="ignoreConstructorParameter" value = "true" />
+			<property name="ignoreConstructorParameter" value = "true"/>
 			<!-- BorderTech: Override from false for setter parameters -->
-			<property name="ignoreSetter" value = "true" />
+			<property name="ignoreSetter" value = "true"/>
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 		<module name="IllegalInstantiation"/>
 		<module name="InnerAssignment"/>
 		<module name="MagicNumber">
 			<!-- BorderTech: Override from false for hash code methods -->
-			<property name="ignoreHashCodeMethod" value = "true" />
+			<property name="ignoreHashCodeMethod" value = "true"/>
 			<!-- BorderTech: Override from false for annotation methods -->
-			<property name="ignoreAnnotation" value = "true" />
+			<property name="ignoreAnnotation" value = "true"/>
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 		<module name="MissingSwitchDefault">
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 		<module name="MultipleVariableDeclarations"/>
 		<module name="SimplifyBooleanExpression"/>
@@ -259,14 +264,14 @@ Checkstyle configuration that checks the sun coding conventions from:
 		<module name="FinalParameters"/>
 		<module name="TodoComment">
 			<!-- BorderTech: Override to warning -->
-			<property name="severity" value="warning" />
+			<property name="severity" value="warning"/>
 		</module>
 		<module name="UpperEll"/>
 
 		<!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
 		<module name="SuppressionXpathFilter">
 			<property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
-					  default="checkstyle-xpath-suppressions.xml" />
+					  default="checkstyle-xpath-suppressions.xml"/>
 			<property name="optional" value="true"/>
 		</module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -150,14 +150,14 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.9.0</version>
+				<version>3.10.1</version>
 			</plugin>
 
 			<!-- Javadoc -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.4.1</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -186,7 +186,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>enforcer</id>
@@ -212,7 +212,7 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.5.1</version>
+						<version>1.6.1</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -86,19 +86,19 @@
 		<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
 
 		<!-- Versions -->
-		<bt.junit.version>5.8.2</bt.junit.version>
-		<bt.jacoco.plugin.version>0.8.7</bt.jacoco.plugin.version>
+		<bt.junit.version>5.9.2</bt.junit.version>
+		<bt.jacoco.plugin.version>0.8.8</bt.jacoco.plugin.version>
 		<bt.surefire.plugin.version>2.22.2</bt.surefire.plugin.version>
-		<bt.checkstyle.plugin.version>3.1.2</bt.checkstyle.plugin.version>
-		<bt.checkstyle.version>9.3</bt.checkstyle.version>
-		<bt.pmd.plugin.version>3.15.0</bt.pmd.plugin.version>
-		<bt.pmd.version>6.42.0</bt.pmd.version>
-		<bt.spotbugs.plugin.version>4.5.3.0</bt.spotbugs.plugin.version>
+		<bt.checkstyle.plugin.version>3.2.1</bt.checkstyle.plugin.version>
+		<bt.checkstyle.version>10.7.0</bt.checkstyle.version>
+		<bt.pmd.plugin.version>3.20.0</bt.pmd.plugin.version>
+		<bt.pmd.version>6.54.0</bt.pmd.version>
+		<bt.spotbugs.plugin.version>4.7.3.0</bt.spotbugs.plugin.version>
 		<bt.sb-contrib.plugin.version>7.4.7</bt.sb-contrib.plugin.version>
-		<bt.spotbugs.version>4.5.3</bt.spotbugs.version>
-		<bt.findsecbugs.plugin.version>1.11.0</bt.findsecbugs.plugin.version>
-		<bt.owasp.plugin.version>6.5.3</bt.owasp.plugin.version>
-		<bt.versions.plugin>2.8.1</bt.versions.plugin>
+		<bt.spotbugs.version>4.7.3</bt.spotbugs.version>
+		<bt.findsecbugs.plugin.version>1.12.0</bt.findsecbugs.plugin.version>
+		<bt.owasp.plugin.version>8.0.2</bt.owasp.plugin.version>
+		<bt.versions.plugin>2.14.2</bt.versions.plugin>
 
 	</properties>
 

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -182,6 +182,14 @@
 
 	<build>
 		<plugins>
+
+			<!-- Surefire -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${bt.surefire.plugin.version}</version>
+			</plugin>
+
 			<!-- Code coverage. -->
 			<plugin>
 				<groupId>org.jacoco</groupId>
@@ -196,21 +204,15 @@
 						</goals>
 					</execution>
 					<!-- Jacoco Coverage Report -->
+					<!-- As this is bound to the same phase as surefire but needs to run after surefire it must be defined after the surefire plugin. -->
 					<execution>
 						<id>post-unit-test</id>
-						<phase>prepare-package</phase>
+						<phase>test</phase>
 						<goals>
 							<goal>report</goal>
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-
-			<!-- Surefire -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>${bt.surefire.plugin.version}</version>
 			</plugin>
 
 			<!-- Verify: Check the code style. -->


### PR DESCRIPTION
* Update plugin dependencies in bordertech_parent
* Update plugin dependencies in qa_parent
* Made the following modifications to CheckStyle config file bt-checkstyle.xml:
  * Moved tabWidth override to the top level checker element
  * Changed tab indention check to no longer allow any violations by removing the maximum property which was set to 10
  * Changed JavadocPackage check to warning
  * Changed EmptyForIteratorPad check to warning as IntelliJ code formatting does not currently allow for this
* Added a new checkstyle config file bt-checkstyle-format-only.xml for projects that only want to check basic code formatting.
* Modified the jacoco report goal to the test phase and to make sure it runs after surefire, moved the jacoco plugin after the surefire plugin in the pom file which is how maven determines the run order of plugins defined on the same phase #88
