### PR TITLE
Update plugin dependencies

### DIFF
--- a/.github/workflows/github-actions-build.yml
+++ b/.github/workflows/github-actions-build.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '8'
         distribution: 'adopt'
 
     - name: Cache Maven Repo
@@ -26,6 +26,12 @@ jobs:
 
     - name: Build Test and Verify
       run: mvn -B -U clean install -Dmaven.javadoc.skip=true -Pdisplay-versions
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'adopt'
 
     - name: SonarCloud Scan
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update to latest plugin dependencies
 * Latest plugin dependencies now have a minimum maven version of 3.6.3.
 * Removed ReturnEmptyArrayRatherThanNull pmd rule that is no longer supported.
+* Modified the versions-maven-plugin phase in the display-versions profile to validate to make it easier to run.
 
 ## 1.0.20
 * Update plugin dependencies in bordertech_parent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## Release in-progress
+* Update to latest plugin dependencies
+* Latest plugin dependencies now have a minimum maven version of 3.6.3.
+* Removed ReturnEmptyArrayRatherThanNull pmd rule that is no longer supported.
 
 ## 1.0.20
 * Update plugin dependencies in bordertech_parent

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Projects should generally use qa-parent as their parent POM:
   <parent>
     <groupId>com.github.bordertech.common</groupId>
     <artifactId>qa-parent</artifactId>
-    <version>1.0.20</version>
+    <version>1.0.21</version>
   </parent>
   ....
 </project>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://github.com/BorderTech/java-common/actions/workflows/github-actions-build.yml/badge.svg)](https://github.com/BorderTech/java-common/actions/workflows/github-actions-build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bordertech-java-common&metric=alert_status)](https://sonarcloud.io/dashboard?id=bordertech-java-common)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=bordertech-java-common&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=bordertech-java-common)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/fd8ef044a86d44e8931410382035f8e2)](https://www.codacy.com/gh/BorderTech/java-common?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=BorderTech/java-common&amp;utm_campaign=Badge_Grade)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.bordertech.common/bordertech-parent.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.github.bordertech.common%22%20AND%20a:%22bordertech-parent%22)
 
 ## Content

--- a/build-tools/src/main/resources/bordertech/bt-pmd-rules.xml
+++ b/build-tools/src/main/resources/bordertech/bt-pmd-rules.xml
@@ -33,9 +33,6 @@
 	<rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod">
 		<priority>3</priority>
 	</rule>
-	<rule ref="category/java/errorprone.xml/ReturnEmptyArrayRatherThanNull">
-		<priority>3</priority>
-	</rule>
 	<rule ref="category/java/errorprone.xml/ReturnEmptyCollectionRatherThanNull">
 		<priority>3</priority>
 	</rule>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>enforcer</id>
@@ -196,7 +196,7 @@
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<version>[3.3.9,)</version>
+									<version>[3.6.3,)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
 									<version>[1.8,)</version>
@@ -212,7 +212,7 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.6.1</version>
+						<version>1.8.0</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -146,7 +146,7 @@
 						<executions>
 							<execution>
 								<id>display-version-updates</id>
-								<phase>verify</phase>
+								<phase>validate</phase>
 								<goals>
 									<goal>display-dependency-updates</goal>
 									<goal>display-parent-updates</goal>

--- a/qa-parent/pom.xml
+++ b/qa-parent/pom.xml
@@ -86,19 +86,20 @@
 		<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
 
 		<!-- Versions -->
-		<bt.junit.version>5.9.2</bt.junit.version>
-		<bt.jacoco.plugin.version>0.8.8</bt.jacoco.plugin.version>
-		<bt.surefire.plugin.version>2.22.2</bt.surefire.plugin.version>
-		<bt.checkstyle.plugin.version>3.2.1</bt.checkstyle.plugin.version>
+		<bt.junit.version>5.11.0</bt.junit.version>
+		<bt.jacoco.plugin.version>0.8.12</bt.jacoco.plugin.version>
+		<bt.surefire.plugin.version>3.5.0</bt.surefire.plugin.version>
+		<bt.checkstyle.plugin.version>3.5.0</bt.checkstyle.plugin.version>
+		<!-- Checkstyle 10.X requires JDK 11 -->
 		<bt.checkstyle.version>9.3</bt.checkstyle.version>
-		<bt.pmd.plugin.version>3.20.0</bt.pmd.plugin.version>
-		<bt.pmd.version>6.54.0</bt.pmd.version>
-		<bt.spotbugs.plugin.version>4.7.3.0</bt.spotbugs.plugin.version>
-		<bt.sb-contrib.plugin.version>7.4.7</bt.sb-contrib.plugin.version>
-		<bt.spotbugs.version>4.7.3</bt.spotbugs.version>
-		<bt.findsecbugs.plugin.version>1.12.0</bt.findsecbugs.plugin.version>
-		<bt.owasp.plugin.version>8.0.2</bt.owasp.plugin.version>
-		<bt.versions.plugin>2.14.2</bt.versions.plugin>
+		<bt.pmd.plugin.version>3.25.0</bt.pmd.plugin.version>
+		<bt.pmd.version>7.5.0</bt.pmd.version>
+		<bt.spotbugs.plugin.version>4.8.6.3</bt.spotbugs.plugin.version>
+		<bt.sb-contrib.plugin.version>7.6.4</bt.sb-contrib.plugin.version>
+		<bt.spotbugs.version>4.8.6</bt.spotbugs.version>
+		<bt.findsecbugs.plugin.version>1.13.0</bt.findsecbugs.plugin.version>
+		<bt.owasp.plugin.version>10.0.4</bt.owasp.plugin.version>
+		<bt.versions.plugin>2.17.1</bt.versions.plugin>
 
 	</properties>
 
@@ -376,6 +377,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>enforcer-convergence-check</id>


### PR DESCRIPTION
* Update to latest plugin dependencies
* Latest plugin dependencies now have a minimum maven version of 3.6.3.
* Removed ReturnEmptyArrayRatherThanNull pmd rule that is no longer supported.
* Modified the versions-maven-plugin phase in the display-versions profile to validate to make it easier to run.